### PR TITLE
Update mc-motd-parser to latest minecraft-motd-parser

### DIFF
--- a/js/routes/tools/id_generator.js
+++ b/js/routes/tools/id_generator.js
@@ -37,6 +37,7 @@ const idTabs = (selected = 0) => {
                                                     min: 1,
                                                     max: 32,
                                                 },
+                                                value: "1"
                                             },
                                         ),
                                     ],

--- a/js/utils/server_pinger.js
+++ b/js/utils/server_pinger.js
@@ -8,7 +8,7 @@
 
 const dgram = require( "dgram" );
 const ByteBuffer = require( "bytebuffer" );
-const motdParser = require( "@sfirew/mc-motd-parser" );
+const motdParser = require( "@sfirew/minecraft-motd-parser" );
 
 const START_TIME = new Date().getTime();
 
@@ -131,7 +131,7 @@ const ping = (host, port = 19132, cb, timeout = 1000) => {
 						},
 						motd: {
 							raw: pong.description,
-							clean: motdParser.cleanTags(pong.description),
+							clean: motdParser.cleanCodes(pong.description),
 							html: bedrockMotd(motdParser.textToHTML(pong.description)),
 						},
 						protocol: Number(pong.protocolVersion),

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	},
 	"dependencies": {
 		"@electron/remote": "^2.0.9",
-		"@sfirew/mc-motd-parser": "^1.1.0",
+		"@sfirew/minecraft-motd-parser": "^1.1.2-1",
 		"babylonjs": "^6.20.1",
 		"bytebuffer": "^5.0.1",
 		"discord-rpc": "^4.0.1",
@@ -42,7 +42,7 @@
 		"appId": "com.xkingdark.bedrocktools",
 		"productName": "Bedrock Tools",
 		"artifactName": "${productName}-${version}.${ext}",
-		"publish":[
+		"publish": [
 			{
 				"provider": "github",
 				"owner": "DarkGamerYT",


### PR DESCRIPTION
I updated mc-motd-parser to latest minecraft-motd-parser

Function `cleanTags` was renamed to `cleanCodes`

`@sfirew/mc-motd-parser@1.1.0: WARNING: This project has been renamed to @sfirew/minecraft-motd-parser. Install using @sfirew/minecraft-motd-parser instead.`